### PR TITLE
don't tag during a dry-run

### DIFF
--- a/src/email_fetcher.py
+++ b/src/email_fetcher.py
@@ -6,10 +6,11 @@ from util import limit_consecutive_linefeeds, safe_decode
 
 class EmailFetcher:
 
-    def __init__(self):
+    def __init__(self, dry_run=False):
         self.host = os.getenv("IMAP_HOST")
         self.username = os.getenv("EMAIL_USERNAME")
         self.password = os.getenv("EMAIL_PASSWORD")
+        self.dry_run = dry_run
 
         self.imapclient = IMAPClient(self.host, ssl=True)
         self.imapclient.login(self.username, self.password)
@@ -75,7 +76,8 @@ class EmailFetcher:
         }
 
     def add_flag(self, message_id, flag):
-        self.imapclient.add_flags(message_id, [flag])
+        if not self.dry_run:
+            self.imapclient.add_flags(message_id, [flag])
 
     def has_flag(self, message_id, flag):
         return flag in self.imapclient.get_flags(message_id)

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ def main(
         fetcher = JSONEmailFetcher(use_json)
         dry_run = True
     else:
-        fetcher = EmailFetcher()
+        fetcher = EmailFetcher(dry_run)
 
     print('-' * 80)
     print(f"Fetching list of folders that start with {os.getenv('FOLDER_PREFIX')}...")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `dry_run` mode for email fetching operations to allow users to test without making actual changes.
  
- **Improvements**
  - Enhanced control over email flagging operations with the new `dry_run` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->